### PR TITLE
fixing typos in report session definition

### DIFF
--- a/views/report.xml
+++ b/views/report.xml
@@ -1,12 +1,5 @@
 <openerp>
 <data>
-    <report
-        id="report_session"
-        model="test_model.session"
-        string="Session Report"
-        name="test_model.report_session_view"
-        file="test_model.report_session"
-        report_type="qweb-pdf" />
 
     <template id="report_session_view">
         <t t-call="report.html_container">
@@ -26,7 +19,15 @@
             </t>
         </t>
     </template>
-    
+
+    <report
+        id="report_session"
+        model="test_module.session"
+        string="Session Report"
+        name="test_module.report_session_view"
+        file="test_module.report_session_view"
+        report_type="qweb-pdf" />
+
 
 </data>
 </openerp>


### PR DESCRIPTION
The problem with the report was that in its definition where it said test_model should be test_module.
Besides that I changed the order of the elements in the xml file because the template element is referenced in the report element (this is not mandatory but it is more readable IMO)